### PR TITLE
Make sure sys/zfs_file.h includes sys/zfs_context.h

### DIFF
--- a/include/sys/zfs_file.h
+++ b/include/sys/zfs_file.h
@@ -22,6 +22,8 @@
 #ifndef	_SYS_ZFS_FILE_H
 #define	_SYS_ZFS_FILE_H
 
+#include <sys/zfs_context.h>
+
 #ifndef _KERNEL
 typedef struct zfs_file {
 	int f_fd;


### PR DESCRIPTION
This is required for FreeBSD to typedef loff_t

Signed-off-by: Allan Jude <allan@klarasystems.com>
